### PR TITLE
Added CATALINA_OPTS in templates and instance.pp manifest

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -16,6 +16,7 @@ define tomcat::instance (
   $runtime_dir                  = '',
 
   $java_opts                    = '-Djava.awt.headless=true -Xmx128m  -XX:+UseConcMarkSweepGC',
+  $catalina_opts                = '',
   $java_home                    = '',
 
   $catalina_properties_template = '',

--- a/templates/instance/defaults6-Debian.erb
+++ b/templates/instance/defaults6-Debian.erb
@@ -13,7 +13,7 @@ TOMCAT6_GROUP=<%= @instance_group %>
 # OpenJDK, the Sun JDK, and various J2SE 1.5 versions are tried.
 <% if @java_home != '' -%>
 JAVA_HOME=<%= @java_home %>
-<% end %>
+<% end -%>
 
 # You may pass JVM startup parameters to Java here. If unset, the default
 # options will be: -Djava.awt.headless=true -Xmx128m -XX:+UseConcMarkSweepGC
@@ -22,7 +22,13 @@ JAVA_HOME=<%= @java_home %>
 # response time). If you use that option and you run Tomcat on a machine with
 # exactly one CPU chip that contains one or two cores, you should also add
 # the "-XX:+CMSIncrementalMode" option.
+<% if @java_opts != '' -%>
 JAVA_OPTS="<%= @java_opts %>"
+<% end -%>
+<% if @catalina_opts != '' -%>
+CATALINA_OPTS="<%= @catalina_opts %>"
+<% end -%>
+
 
 # Java compiler to use for translating JavaServer Pages (JSPs). You can use all
 # compilers that are accepted by Ant's build.compiler property.

--- a/templates/instance/defaults6-RedHat.erb
+++ b/templates/instance/defaults6-RedHat.erb
@@ -19,7 +19,7 @@
 # Where your java installation lives
 <% if @java_home != '' -%>
 JAVA_HOME=<%= @java_home %>
-<% end %>
+<% end -%>
 
 # Where your tomcat installation lives
 CATALINA_BASE="/var/lib/tomcat6-<%= @instance_name %>"
@@ -28,7 +28,13 @@ CATALINA_BASE="/var/lib/tomcat6-<%= @instance_name %>"
 #CATALINA_TMPDIR="/var/cache/tomcat6/temp"
 
 # You can pass some parameters to java here if you wish to
+<% if @java_opts != '' -%>
 JAVA_OPTS="<%= @java_opts %>"
+<% end -%>
+<% if @catalina_opts != '' -%>
+CATALINA_OPTS="<%= @catalina_opts %>"
+<% end -%>
+
 
 # What user should run tomcat
 TOMCAT_USER="<%= @instance_owner %>"

--- a/templates/instance/defaults7-Debian.erb
+++ b/templates/instance/defaults7-Debian.erb
@@ -13,7 +13,7 @@ TOMCAT7_GROUP=<%= @instance_group %>
 # OpenJDK, the Sun JDK, and various J2SE 1.5 versions are tried.
 <% if @java_home != '' -%>
 JAVA_HOME=<%= @java_home %>
-<% end %>
+<% end -%>
 
 # You may pass JVM startup parameters to Java here. If unset, the default
 # options will be: -Djava.awt.headless=true -Xmx128m -XX:+UseConcMarkSweepGC
@@ -22,7 +22,12 @@ JAVA_HOME=<%= @java_home %>
 # response time). If you use that option and you run Tomcat on a machine with
 # exactly one CPU chip that contains one or two cores, you should also add
 # the "-XX:+CMSIncrementalMode" option.
+<% if @java_opts != '' -%>
 JAVA_OPTS="<%= @java_opts %>"
+<% end -%>
+<% if @catalina_opts != '' -%>
+CATALINA_OPTS="<%= @catalina_opts %>"
+<% end -%>
 
 # Java compiler to use for translating JavaServer Pages (JSPs). You can use all
 # compilers that are accepted by Ant's build.compiler property.


### PR DESCRIPTION
This change give the possibility to use also CATALINA_OPTS variable to define some directive of Tomcat.

JAVA_OPTS it's used to start/stop and run Tomcat
CATALINA_OPTS it's used to start/run Tomcat

So it's good to be able to manage both variables, i.e. you could have a really high Xmx to start Tomcat, but to stop it you don't need so much memory in the JVM.

Also, on REDHAT if you set a JMX port in the java_opts the init script will fail in stopping tomcat giving an error such as port XXXX already in use, so in this case you must set this directive in catalina_opts
