### PR TITLE
Remove 2.6 from travis and add 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ rvm:
 script:
   - "rake spec SPEC_OPTS='--format documentation'"
 env:
-  - PUPPET_VERSION="~> 2.6.0"
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.2.0"
 matrix:
   exclude:
     - rvm: 1.9.3


### PR DESCRIPTION
Hi,

As say in PR #16 I've remove puppet 2.6 from travis ci test.

I've also add the 3.2 puppet version.

I hope this will work great :).
