### PR TITLE
Added differents options for the instance

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -6,6 +6,9 @@ define tomcat::instance (
   $control_port,
   $ajp_port                     = '',
   $instance_autorestart         = 'true',
+  $service_enable               = 'true',
+  $service_ensure               = 'running',
+  $service_hasrestart           = 'true',
 
   $dirmode                      = '0755',
   $filemode                     = '0644',
@@ -57,6 +60,11 @@ define tomcat::instance (
   ) {
 
   require tomcat::params
+
+  $ensure_real = $service_ensure ? {
+    'undef' => undef,
+    default => $service_ensure,
+  }
 
   $bool_instance_autorestart=any2bool($instance_autorestart)
   $bool_manager=any2bool($manager)
@@ -169,13 +177,13 @@ define tomcat::instance (
 
   # Running service
   service { "tomcat-${instance_name}":
-    ensure     => running,
-    name       => "${tomcat::params::pkgver}-${instance_name}",
-    enable     => true,
-    pattern    => $instance_name,
-    hasrestart => true,
-    hasstatus  => $tomcat::params::service_status,
-    require    => Exec["instance_tomcat_${instance_name}"],
+      ensure     => $ensure_real,
+      name       => "${tomcat::params::pkgver}-${instance_name}",
+      enable     => $service_enable,
+      pattern    => $instance_name,
+      hasrestart => $service_hasrestart,
+      hasstatus  => $tomcat::params::service_status,
+      require => Exec["instance_tomcat_${instance_name}"],
   }
 
   # Create service initd file


### PR DESCRIPTION
On some servers we use monit to manage the current status of any instance (start and stop them) and so we don't want that pupppet agent do any action on their status.

So I changed the default "running" to a variable, now it's possible to use undef to not check the instance ensure parameter.

Similarly on some servers we need to be able to choose if we want to enable the instances at boot or not.

I've put the old values as default so this change should be backward compatible.
