### PR TITLE
Fix ajp_port variable name

### DIFF
--- a/templates/modjk.worker.properties
+++ b/templates/modjk.worker.properties
@@ -2,7 +2,7 @@
 # Defining a worker named <%=name %>_worker and of type ajp13
 # Note that the name and the type do not have to match.
 # 
-worker.<%= instance_name %>_worker.port=<%= ajpport %>
+worker.<%= instance_name %>_worker.port=<%= ajp_port %>
 worker.<%= instance_name %>_worker.host=localhost
 worker.<%= instance_name %>_worker.type=ajp13
 # 


### PR DESCRIPTION
Hi,

The current template "modjk.worker.properties" used to automaticaly bind a tomcat instance to mod jk use the unavariable variable $ajpport. The right variable is ajp_port (with underscore). This pull request correct that.

Fill free to comment and/or merge.

Regards